### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "email": "support@auroraextensions.com"
   },
   "require": {
-    "php": "~7.1.0||~7.2.0||~7.3.0||~7.4.0",
+    "php": "~7.1.0||~7.2.0||~7.3.0||~7.4.0||^8.0||^8.1",
     "magento/framework": "^100||^101||^102||^103",
     "magento/module-ui": "*"
   },


### PR DESCRIPTION
Ran phpcs (PHP CodeSniffer) against repository and saw no PHP 8.0 and PHP 8.1 compatibility issues.

Allowing PHP 8.1 since Magento 2.4.4 supports PHP 8.1